### PR TITLE
Feature/vish

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,29 @@
-# Use the root requirements as the single source of truth
--r ../requirements.txt
+###########################################################
+# Backend (FastAPI) requirements — pinned for reproducibility
+# These are derived from imports in backend/app/* and backend/*
+###########################################################
+
+# Core API
+fastapi==0.115.5
+uvicorn[standard]==0.34.0
+pydantic==2.9.2
+
+# Data/ML runtime for inference (for joblib + sklearn pipeline)
+pandas==2.3.2
+numpy==2.3.3
+scikit-learn==1.7.2
+scipy==1.16.2
+joblib==1.5.2
+
+# File uploads and spreadsheet support
+python-multipart==0.0.10
+openpyxl==3.1.5
+XlsxWriter==3.2.0
+xlrd==2.0.1
+
+# Optional PDF export (if installed, API enables PDF export)
+reportlab==4.2.5
+
+# Note:
+# - Keep backend-only deps here to keep the API image slim.
+# - Versions aligned with the root requirements to avoid drift.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,20 @@
+services:
+  - type: web
+    name: heartsense-api
+    env: python
+    plan: free
+    repo: https://github.com/SYNCODE-SLIIT/Heart-Disease
+    branch: main
+    buildCommand: pip install -r backend/requirements.txt
+    startCommand: gunicorn -k uvicorn.workers.UvicornWorker app.main:app --chdir backend --bind 0.0.0.0:$PORT --workers 1 --timeout 120
+    envVars:
+      - key: MODEL_PATH
+        value: heart_rf_pipeline_compressed.pkl   # or heart_rf_pipeline.pkl if not compressed
+      - key: THRESHOLD_PATH
+        value: decision_threshold.json
+      - key: ALLOWED_ORIGINS
+        value: "*"
+      - key: API_V1_PREFIX
+        value: "/api"
+      - key: MODEL_VERSION
+        value: "1.0.0"


### PR DESCRIPTION
This pull request sets up the backend deployment for the FastAPI service and pins the backend dependencies for reproducibility and maintainability. The most important changes are grouped below.

**Deployment Configuration:**

* Added a new `render.yaml` file to define the deployment of the FastAPI backend service (`heartsense-api`) on Render, including environment variables, build, and start commands.

**Dependency Management:**

* Replaced the previous approach of inheriting root requirements in `backend/requirements.txt` with a fully pinned list of backend-specific dependencies, ensuring reproducibility and a slimmer API image.
* Explicitly listed and pinned versions for core API libraries (`fastapi`, `uvicorn`, `pydantic`) and data/ML dependencies (`pandas`, `numpy`, `scikit-learn`, `scipy`, `joblib`).
* Added support for file uploads, spreadsheet handling, and optional PDF export by including relevant packages (`python-multipart`, `openpyxl`, `XlsxWriter`, `xlrd`, `reportlab`).