### PR TITLE
fixed origins

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -14,7 +14,7 @@ MODEL_VERSION = "local-dev"
 
 # CORS settings
 ALLOWED_ORIGINS = [
-    "https://heart-disease-zhh3.vercel.app",
+    "heart-disease-phi.vercel.app",
     "http://localhost:3000",
     "http://127.0.0.1:3000",
 ]


### PR DESCRIPTION
This pull request updates the allowed origins for CORS in the backend settings. The change ensures that only the correct frontend deployment can interact with the backend.

* Updated the `ALLOWED_ORIGINS` list in `backend/app/settings.py` to replace the old frontend domain with the new deployment at `heart-disease-phi.vercel.app`.