### PR TITLE
fixed origins

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -15,6 +15,7 @@ MODEL_VERSION = "local-dev"
 # CORS settings
 ALLOWED_ORIGINS = [
     "heart-disease-phi.vercel.app",
+    "https://heart-disease-phi.vercel.app",
     "http://localhost:3000",
     "http://127.0.0.1:3000",
 ]


### PR DESCRIPTION
This pull request makes a small update to the CORS settings in `backend/app/settings.py` to ensure that requests from the deployed frontend are properly allowed.

* Added the full `https://heart-disease-phi.vercel.app` origin to the `ALLOWED_ORIGINS` list to support requests from the deployed frontend.